### PR TITLE
Clarify stream-state timing and align RESET_STREAM_AT flow-control text with RESET_STREAM

### DIFF
--- a/draft-ietf-quic-reliable-stream-reset.md
+++ b/draft-ietf-quic-reliable-stream-reset.md
@@ -141,6 +141,15 @@ Reliable Size:
 If the Reliable Size is larger than the Final Size, the receiver MUST close the
 connection with a connection error of type FRAME_ENCODING_ERROR.
 
+As with RESET_STREAM ({{Section 19.4 of RFC9000}}), Final Size is subject to
+stream flow control. An endpoint MUST NOT send a RESET_STREAM_AT frame with a
+Final Size larger than the largest maximum stream data value advertised by the
+receiver. Consequently, the sender might need to defer sending RESET_STREAM_AT
+until enough stream flow control credit is available. If an endpoint receives a
+RESET_STREAM_AT frame with a Final Size larger than the advertised maximum
+stream data value, it MUST close the connection with an error of type
+FLOW_CONTROL_ERROR.
+
 RESET_STREAM_AT frames are ack-eliciting, and MUST only be sent in the
 application data packet number space. When lost, they MUST be retransmitted,
 unless the stream state has transitioned to "Data Recvd" or "Reset Recvd" due to

--- a/draft-ietf-quic-reliable-stream-reset.md
+++ b/draft-ietf-quic-reliable-stream-reset.md
@@ -142,12 +142,13 @@ If the Reliable Size is larger than the Final Size, the receiver MUST close the
 connection with a connection error of type FRAME_ENCODING_ERROR.
 
 As with RESET_STREAM ({{Section 19.4 of RFC9000}}), Final Size is subject to
-stream flow control. An endpoint MUST NOT send a RESET_STREAM_AT frame with a
-Final Size larger than the largest maximum stream data value advertised by the
-receiver. Consequently, the sender might need to defer sending RESET_STREAM_AT
-until enough stream flow control credit is available. If an endpoint receives a
-RESET_STREAM_AT frame with a Final Size larger than the advertised maximum
-stream data value, it MUST close the connection with an error of type
+stream and connection-level flow control. An endpoint MUST NOT send a
+RESET_STREAM_AT frame that exceeds the largest maximum stream data value
+advertised by the receiver for the stream, or that violates the receiver's
+maximum data limit. Consequently, the sender might need to defer sending
+RESET_STREAM_AT until enough stream or connection-level flow control credit is
+available. If an endpoint receives a RESET_STREAM_AT frame that violates either
+flow control limit, it MUST close the connection with an error of type
 FLOW_CONTROL_ERROR.
 
 RESET_STREAM_AT frames are ack-eliciting, and MUST only be sent in the

--- a/draft-ietf-quic-reliable-stream-reset.md
+++ b/draft-ietf-quic-reliable-stream-reset.md
@@ -230,15 +230,18 @@ carrying the smallest Reliable Size and all stream data up to that byte offset
 have been acknowledged, the sending part of the stream enters the "Data Recvd"
 state. The transition from "Data Sent" to "Data Recvd" happens immediately if
 the application resets a stream and all bytes up to the specified Reliable Size
-have already been sent and acknowledged. Conversely, the transition might take
-multiple network roundtrips or require additional flow control credit issued by
+have already been sent and acknowledged. Conversely, if bytes below that offset
+still need to be sent or acknowledged, the transition might take multiple
+network roundtrips and might require additional flow control credit issued by
 the receiver.
 
 On the receiving side, when a RESET_STREAM_AT frame is received, the receiving
 part of the stream enters the "Size Known" state. Once all data up to the
 smallest Reliable Size have been received, it enters the "Data Recvd" state.
 Similarly to the sending side, transition from "Size Known" to "Data Recvd"
-might happen immediately or involve issuance of additional flow control credit.
+might happen immediately, or might require additional network roundtrips while
+the sender transmits remaining bytes up to the smallest Reliable Size. This might
+require the receiver to issue additional flow control credit.
 
 # Implementation Guidance
 


### PR DESCRIPTION
This PR is an editorial change, clarifying the following two points to help implementers:
* Stream States timing clarification: It clarifies that transitions to Data Recvd may take additional RTTs when bytes up to Reliable Size are still outstanding, and that additional flow-control credit might be needed in that process.
* RESET_STREAM_AT flow-control clarification: It makes explicit that RESET_STREAM_AT follows the same flow-control model as RESET_STREAM (RFC 9000): Final Size is bounded by advertised max stream data.

Closes #78.