### PR TITLE
Correct an error code mismatch

### DIFF
--- a/draft-ietf-quic-reliable-stream-reset.md
+++ b/draft-ietf-quic-reliable-stream-reset.md
@@ -209,7 +209,8 @@ increases the Reliable Size.
 When sending another RESET_STREAM_AT, RESET_STREAM or STREAM frame carrying a FIN
 bit for the same stream, the initiator MUST NOT change the Application Error
 Code or the Final Size. If the receiver detects a change in those fields, it
-MUST close the connection with a connection error of type STREAM_STATE_ERROR.
+MUST close the connection with a connection error of type STREAM_STATE_ERROR
+or FINAL_SIZE_ERROR, respectively.
 
 While multiple RESET_STREAM_AT frames can reduce Reliable Size, some
 applications might need to ensure that a minimum amount of data is always


### PR DESCRIPTION
This matches the base spec, so it is necessary if people are going to share implementations of the RESET_STREAM types.  On the other hand, that code doesn't work for a change in the error code.  Keep what you had originally.

https://quicwg.org/reliable-stream-reset/draft-ietf-quic-reliable-stream-reset.html#section-5-5 says FINAL_SIZE_ERROR now.  Keep that and don't try to do anything fancy.

This just updates https://quicwg.org/reliable-stream-reset/draft-ietf-quic-reliable-stream-reset.html#section-5.2-5