### PR TITLE
Update status text to reflect the new 0x1d codepoint

### DIFF
--- a/draft-ietf-quic-reliable-stream-reset.md
+++ b/draft-ietf-quic-reliable-stream-reset.md
@@ -293,7 +293,7 @@ Parameter Name:
 : reset_stream_at
 
 Status:
-: Provisional (note that, prior to publication, the value will be replaced by a new value lower than 64)
+: Provisional (will become Permanent once this document is approved)
 
 Specification:
 : This document


### PR DESCRIPTION
Noticed during shepherd (re)review. This is not blocking and can be incorporated alongside any AD feedback